### PR TITLE
Added GitHub release badge, fixed badge colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # locale-match
 
 [![crates.io](https://img.shields.io/crates/v/locale-match?style=for-the-badge&logo=rust)](https://crates.io/crates/locale-match)
-[![crates.io](https://img.shields.io/docsrs/locale-match/latest?style=for-the-badge&logo=docs.rs
-)](https://docs.rs/locale-match/latest/locale_match)
+[![crates.io](https://img.shields.io/docsrs/locale-match/latest?style=for-the-badge&logo=docs.rs&color=2DA44E)](https://docs.rs/locale-match/latest/locale_match)
+[![crates.io](https://img.shields.io/github/v/release/pasabanov/locale-match?style=for-the-badge&logo=github&color=8250DF)](https://github.com/pasabanov/locale-match/releases/latest)
 
 A small library for matching a locale from a list of available locales to the user's preferred locales.
 
@@ -95,5 +95,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ## Metrics
 
-![repo size](https://img.shields.io/github/repo-size/pasabanov/locale-match?color=6e54bb)
+![repo size](https://img.shields.io/github/repo-size/pasabanov/locale-match?color=8250DF)
 ![crate size](https://img.shields.io/crates/size/locale-match?label=crate%20size&color=orange)


### PR DESCRIPTION
**PR Type**  
- [x] Other: readme badges

**Describe changes**  
1. Added GitHub release badge at the top of the `README.md`.
2. Changed the color of the `repo size` badge at the bottom of the `README.md` from `6e54bb` to `8250DF`.