### PR TITLE
Configured line endings to '\n'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,5 @@ root = true
 [*]
 charset = utf-8
 indent_style = tab
+end_of_line = lf
 insert_final_newline = false

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
         <option name="SMART_TABS" value="true" />
       </value>
     </option>
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <codeStyleSettings language="Bibtex">
       <indentOptions>
         <option name="USE_TAB_CHARACTER" value="true" />

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,8 @@
 	"editor.detectIndentation": true,
 	"editor.indentSize": "tabSize",
 	"editor.insertSpaces": false,
+	// New lines
+	"files.eol": "\n",
 	// Final new line
 	"files.insertFinalNewline": false,
 	"files.trimFinalNewlines": true,


### PR DESCRIPTION
### Types of changes
- Configuration (code style)

Related: #14

### Description
Set line endings to `\n` (line feed):
* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR6): Added `end_of_line = lf`.
* [`.idea/codeStyles/Project.xml`](diffhunk://#diff-11745b49c51a1ecde7d4d4cffda53d76594e6711ec81bf1148a05942b0438141R10): Added `<option name="LINE_SEPARATOR" value="&#10;" />`.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R37-R38): Added `"files.eol": "\n"`.