### PR TITLE
Removed periods from comments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Both modules provide the `best_matching_locale` function.
 To use `locale-match` in your project, add it to your `Cargo.toml`:
 
 ```toml
-# Both modules are included by default.
+# Both modules are included by default
 locale-match = "x.y.z"
 
-# Include only the `bcp47` module.
+# Include only the `bcp47` module
 locale-match = { version = "x.y.z", default-features = false, features = ["bcp47"] }
 
-# Include only the `posix` module.
+# Include only the `posix` module
 locale-match = { version = "x.y.z", default-features = false, features = ["posix"] }
 ```
 


### PR DESCRIPTION
### Types of changes
- Project documents (readme)

Related: #26

### Description
Removed periods from comments in the `toml` code block under the `Usage` header in `README.md`.
The code block seems more readable without them.