### PR TITLE
Renamed `fastcompile` profile to `fastbuild`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ lto = false
 debug = true
 strip = "none"
 
-[profile.fastcompile]
+[profile.fastbuild]
 inherits = "dev"
 # Compilation
 codegen-units = 8192


### PR DESCRIPTION
### Types of changes
- Configuration (build)

Related: 218c71cae8b25ef4584b4607537e658b411ab346

### Description
Renamed `fastcompile` profile to `fastbuild`.